### PR TITLE
messing around with landing page to make it more like Quizlet's

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,11 +1,7 @@
-import DeployButton from "@/components/deploy-button";
-import { EnvVarWarning } from "@/components/env-var-warning";
-import HeaderAuth from "@/components/header-auth";
+// app/layout.tsx -> root layout wraps all routes in the app
 import { ThemeSwitcher } from "@/components/theme-switcher";
-import { hasEnvVars } from "@/utils/supabase/check-env-vars";
 import { Geist } from "next/font/google";
 import { ThemeProvider } from "next-themes";
-import Link from "next/link";
 import "./globals.css";
 
 const defaultUrl = process.env.VERCEL_URL
@@ -14,8 +10,8 @@ const defaultUrl = process.env.VERCEL_URL
 
 export const metadata = {
   metadataBase: new URL(defaultUrl),
-  title: "Next.js and Supabase Starter Kit",
-  description: "The fastest way to build apps with Next.js and Supabase",
+  title: "AU Study App",
+  description: "Your personal study assistant",
 };
 
 const geistSans = Geist({
@@ -37,39 +33,10 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          <main className="min-h-screen flex flex-col items-center">
-            <div className="flex-1 w-full flex flex-col gap-20 items-center">
-              <nav className="w-full flex justify-center border-b border-b-foreground/10 h-16">
-                <div className="w-full max-w-5xl flex justify-between items-center p-3 px-5 text-sm">
-                  <div className="flex gap-5 items-center font-semibold">
-                    <Link href={"/"}>Next.js Supabase Starter</Link>
-                    <div className="flex items-center gap-2">
-                      <DeployButton />
-                    </div>
-                  </div>
-                  {!hasEnvVars ? <EnvVarWarning /> : <HeaderAuth />}
-                </div>
-              </nav>
-              <div className="flex flex-col gap-20 max-w-5xl p-5">
-                {children}
-              </div>
-
-              <footer className="w-full flex items-center justify-center border-t mx-auto text-center text-xs gap-8 py-16">
-                <p>
-                  Powered by{" "}
-                  <a
-                    href="https://supabase.com/?utm_source=create-next-app&utm_medium=template&utm_term=nextjs"
-                    target="_blank"
-                    className="font-bold hover:underline"
-                    rel="noreferrer"
-                  >
-                    Supabase
-                  </a>
-                </p>
-                <ThemeSwitcher />
-              </footer>
-            </div>
-          </main>
+          {children}
+          <footer className="fixed bottom-4 right-4">
+            <ThemeSwitcher />
+          </footer>
         </ThemeProvider>
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,16 +1,129 @@
-import Hero from "@/components/hero";
-import ConnectSupabaseSteps from "@/components/tutorial/connect-supabase-steps";
-import SignUpUserSteps from "@/components/tutorial/sign-up-user-steps";
-import { hasEnvVars } from "@/utils/supabase/check-env-vars";
+// app.page.tsx -- Root page @ /
+import Link from "next/link";
+import { BookOpen, FileText, ClipboardList, Check, Sparkles } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardHeader, CardContent } from "@/components/ui/card";
+import { LandingHeader } from "@/components/landing-header"
 
-export default async function Home() {
+export default function Home() {
   return (
-    <>
-      <Hero />
-      <main className="flex-1 flex flex-col gap-6 px-4">
-        <h2 className="font-medium text-xl mb-4">Next steps</h2>
-        {hasEnvVars ? <SignUpUserSteps /> : <ConnectSupabaseSteps />}
+    <div className="min-h-screen">
+      {/* Create & Log in header */}
+      <LandingHeader/>
+
+      {/* Main Content*/}
+      <main className= "flex-1">
+      {/* Hero Section */}
+        <section className="text-center py-12 pt-24">
+            <h1 className="text-4xl md:text-5xl font-bold tracking-tight mb-4">
+              Need to Study?
+            </h1>
+            <p className="text-xl text-muted-foreground max-w-3xl mx-auto mb-8">
+              Master whatever you're learning with AI-powered flashcards, practice tests, and personalized study activities.
+            </p>
+            <div className="flex justify-center gap-4">
+              <Link href="/auth?signup=true">
+                <Button size="lg">Sign up for free</Button>
+              </Link>
+            </div>
+        </section>
+
+        {/* Features Section */}
+        <section className="py-16 px-4 w-full">
+          <div className="max-w-7xl mx-auto grid grid-cols-1 md:grid-cols-3 gap-8">
+            
+            {/* Study Guides Card */}
+            <Card className="hover:shadow-lg transition-shadow h-full">
+              <CardHeader>
+                <div className="flex items-center justify-center w-12 h-12 bg-primary/10 rounded-full mb-4 mx-auto">
+                  <BookOpen className="w-6 h-6 text-primary" />
+                </div>
+                <h3 className="text-2xl font-semibold text-center">Study Guides</h3>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="flex items-start gap-3">
+                  <Check className="w-5 h-5 mt-0.5 text-primary flex-shrink-0" />
+                  <p>AI-generated custom study guides from your uploads</p>
+                </div>
+                <div className="flex items-start gap-3">
+                  <Check className="w-5 h-5 mt-0.5 text-primary flex-shrink-0" />
+                  <p>Key points organized for clarity and focus</p>
+                </div>
+                <div className="flex items-start gap-3">
+                  <Check className="w-5 h-5 mt-0.5 text-primary flex-shrink-0" />
+                  <p>Edit, expand, or simplify — your way</p>
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Flashcards Card */}
+            <Card className="hover:shadow-lg transition-shadow h-full">
+              <CardHeader>
+                <div className="flex items-center justify-center w-12 h-12 bg-primary/10 rounded-full mb-4 mx-auto">
+                  <FileText className="w-6 h-6 text-primary" />
+                </div>
+                <h3 className="text-2xl font-semibold text-center">Flashcards</h3>
+              </CardHeader>
+              <CardContent className="space-y-4">
+              <div className="flex items-start gap-3">
+                  <Check className="w-5 h-5 mt-0.5 text-primary flex-shrink-0" />
+                  <p>Master topics faster with flashcards</p>
+                </div>
+                <div className="flex items-start gap-3">
+                  <Check className="w-5 h-5 mt-0.5 text-primary flex-shrink-0" />
+                  <p>Spaced reptition just for you</p>
+                </div>
+                <div className="flex items-start gap-3">
+                  <Check className="w-5 h-5 mt-0.5 text-primary flex-shrink-0" />
+                  <p>Generated from your own study materials</p>
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Practice Tests Card */}
+            <Card className="hover:shadow-lg transition-shadow h-full">
+              <CardHeader>
+                <div className="flex items-center justify-center w-12 h-12 bg-primary/10 rounded-full mb-4 mx-auto">
+                  <ClipboardList className="w-6 h-6 text-primary" />
+                </div>
+                <h3 className="text-2xl font-semibold text-center">Practice Tests</h3>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="flex items-start gap-3">
+                  <Check className="w-5 h-5 mt-0.5 text-primary flex-shrink-0" />
+                  <p>Ace your exams with practice tests</p>
+                </div>
+                <div className="flex items-start gap-3">
+                  <Check className="w-5 h-5 mt-0.5 text-primary flex-shrink-0" />
+                  <p>Get personalized difficulty adjustments</p>
+                </div>
+                <div className="flex items-start gap-3">
+                  <Check className="w-5 h-5 mt-0.5 text-primary flex-shrink-0" />
+                  <p>Instant feedback with concept</p>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </section>
+
+        {/* CTA Section */}
+        <section className="py-16 px-4 bg-background w-full">
+          <div className="max-w-7xl mx-auto text-center">
+            <h2 className="text-3xl font-bold tracking-tight mb-4">
+              Every subject, every test - one powerful AI study assistant
+            </h2>
+            <p className="text-xl text-muted-foreground mb-8 max-w-3xl mx-auto">
+              Create your own study materials or let our AI generate them for you. Study anytime, anywhere with your personal learning companion.
+            </p>
+            <Link href="/auth">
+              <Button size="lg" className="gap-2">
+                Get Started
+                <Sparkles className="w-5 h-5" />
+              </Button>
+            </Link>
+          </div>
+        </section>
       </main>
-    </>
+    </div>
   );
 }

--- a/components/landing-header.tsx
+++ b/components/landing-header.tsx
@@ -1,0 +1,18 @@
+// components/landing-header.tsx (new custom header)
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+export function LandingHeader() {
+  return (
+    <header className="w-full flex justify-end p-4 sticky top-0 z-50 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 border-b">
+      <div className="flex gap-4">
+        <Link href="/auth?signup=true">
+          <Button variant="ghost">+ Create</Button>
+        </Link>
+        <Link href="/auth">
+          <Button>Log In</Button>
+        </Link>
+      </div>
+    </header>
+  );
+}

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,79 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      className
+    )}
+    {...props}
+  />
+))
+Card.displayName = "Card"
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+))
+CardHeader.displayName = "CardHeader"
+
+const CardTitle = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "text-2xl font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+CardTitle.displayName = "CardTitle"
+
+const CardDescription = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+CardDescription.displayName = "CardDescription"
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+))
+CardContent.displayName = "CardContent"
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+))
+CardFooter.displayName = "CardFooter"
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }


### PR DESCRIPTION
Quizlet Landing Page: 
![image](https://github.com/user-attachments/assets/bbfdb057-0c46-4c8f-82fd-1731ede6a76e)

Our app's landing page (could be prettier, still a work in progress): 
![image](https://github.com/user-attachments/assets/d0396721-a033-409d-8b64-1726eafac040)

- Simplified root layout `app/layout.tsx,` modified `app/page.tsx` (landing page), created `app/components/landing-header` for the  + create & login functionality, added Shadcn card component `app/components/ui/card`

- Still need to create routes and edit pages for login & sign up (clicking any of the buttons `sign-up for free`, `login`, `create` and `get started`  routes to login/signup page) 