### PR TITLE
70 s5 create a server action to create flashcards

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -9,6 +9,7 @@ import { PdfToTextConverter } from "@/utils/file-converters/pdf-converter";
 import { DocsxToTextConverter } from "@/utils/file-converters/docx-converter";
 import { PptxToTextConverter } from "@/utils/file-converters/pptx-converter";
 import { generateStudyGuide } from "@/utils/ai/generate-study-guide";
+import generateFlashcards from "@/utils/ai/generate-flashcards";
 import storeFile from "@/utils/file/store-file";
 
 export async function signUpAction(formData: FormData) {
@@ -267,6 +268,63 @@ export async function createStudyGuide(formData: FormData) {
     };
   } catch (error) {
     console.error("Error creating study guide:", error);
+    return {
+      success: false,
+      message: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+}
+
+export async function createFlashcardsFromStudyGuide(
+  studyGuideId: string,
+  title: string,
+  folder_id?: string
+) {
+  try {
+    const supabase = await createClient();
+    if (!studyGuideId) throw new Error("Study guide id is absent");
+
+    const { data: fileInfo, error: get_orig_file_err } = (await supabase.rpc(
+      "get_orig_file",
+      {
+        studyGuideId,
+      }
+    )) as { data: { name: string; bucket: string }; error: any };
+
+    if (get_orig_file_err) throw new Error(get_orig_file_err.message);
+
+    if (!fileInfo)
+      throw new Error(
+        `Didn't find original file for stugy guide with id=${studyGuideId}`
+      );
+
+    const { data: file, error: file_err } = await supabase.storage
+      .from(fileInfo.bucket)
+      .download(fileInfo.name);
+
+    if (file_err) throw new Error(file_err.message);
+
+    const content = await file.text();
+    const flashcards = await generateFlashcards(content);
+    let { data, error: creat_flashcard_set_err } = await supabase.rpc(
+      "create_flashcard_set",
+      {
+        flashcards,
+        p_folder_id: folder_id,
+        p_study_guide_id: studyGuideId,
+        set_title: title,
+      }
+    );
+
+    if (creat_flashcard_set_err)
+      throw new Error(creat_flashcard_set_err.message);
+
+    return {
+      success: true,
+      message: "Flashcard set was successfully created",
+    };
+  } catch (error) {
+    console.error("Error creating flashcard set from stugy guide:", error);
     return {
       success: false,
       message: error instanceof Error ? error.message : "Unknown error",

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,0 @@
-module.exports = {
-  presets: ["next/babel"],
-};

--- a/utils/ai/generate-flashcards.ts
+++ b/utils/ai/generate-flashcards.ts
@@ -1,5 +1,6 @@
 import ai from "./create-ai";
 import { Type } from "@google/genai";
+import { createClient } from "@/utils/supabase/server";
 
 const DEFAULT_MODEL = "gemini-2.0-flash-lite";
 const SYSTEM_INSTRUCTIONS = `
@@ -49,4 +50,27 @@ export default async function generateFlashcards(
     message: `Number of flashcards to be generated is ${count}` + text,
   });
   return res as Flashcard[];
+}
+
+export async function createFlashcardSet(
+  text: string,
+  set_title: string,
+  p_folder_id?: string,
+  p_study_guide_id?: string
+) {
+  const supabase = await createClient();
+  const flashcards = await generateFlashcards(text);
+  let { data, error: creat_flashcard_set_err } = await supabase.rpc(
+    "create_flashcard_set",
+    {
+      flashcards,
+      p_folder_id,
+      p_study_guide_id,
+      set_title,
+    }
+  );
+
+  if (creat_flashcard_set_err) throw new Error(creat_flashcard_set_err.message);
+
+  return data;
 }

--- a/utils/ai/generate-flashcards.ts
+++ b/utils/ai/generate-flashcards.ts
@@ -1,0 +1,55 @@
+import ai from "./create-ai";
+import { Type } from "@google/genai";
+
+const DEFAULT_MODEL = "gemini-2.0-flash-lite";
+const SYSTEM_INSTRUCTIONS = `
+  You are an assistant designed to help students create learning materials from their notes.
+  You will be given a peice of text.
+  Your task is to create a set of flashcards from provided text.
+  Flashcards should cover different topics from the provided text.
+`.trim();
+
+export type Flashcard = {
+  question: string;
+  answer: string;
+};
+
+const FLASHCARD_SCHEMA = {
+  type: Type.ARRAY,
+  items: {
+    type: Type.OBJECT,
+    properties: {
+      question: {
+        type: Type.STRING,
+        description: "Front side of the flashcard. Contains the question",
+        nullable: false,
+      },
+      answer: {
+        type: Type.STRING,
+        description: "Back side of the flashcard. Contains the answer",
+        nullable: false,
+      },
+    },
+    required: ["question", "answer"],
+  },
+};
+export default async function generateFlashcards({
+  text,
+  count = 20,
+}: {
+  text: string;
+  count?: number;
+}) {
+  const chat = ai.chats.create({
+    model: process.env.GEMINI_MODEL || DEFAULT_MODEL,
+    config: {
+      systemInstruction: SYSTEM_INSTRUCTIONS,
+      responseMimeType: "application/json",
+      responseSchema: FLASHCARD_SCHEMA,
+    },
+  });
+  const { text: res = {} } = await chat.sendMessage({
+    message: `Number of flashcards to be generated is ${count}` + text,
+  });
+  return res as Flashcard[];
+}

--- a/utils/ai/generate-flashcards.ts
+++ b/utils/ai/generate-flashcards.ts
@@ -33,13 +33,10 @@ const FLASHCARD_SCHEMA = {
     required: ["question", "answer"],
   },
 };
-export default async function generateFlashcards({
-  text,
-  count = 20,
-}: {
-  text: string;
-  count?: number;
-}) {
+export default async function generateFlashcards(
+  text: string,
+  count: number = 20
+) {
   const chat = ai.chats.create({
     model: process.env.GEMINI_MODEL || DEFAULT_MODEL,
     config: {


### PR DESCRIPTION
I've created server actions to create flashcard set from:
1. Existing study guide (its original file)
2. From upload/input

In order to update database tables I used rpc to apply changes in transaction.
Here's the function
```sql
CREATE OR REPLACE FUNCTION create_flashcard_set(
    set_title TEXT,
    flashcards JSONB[],
    p_folder_id UUID,
    p_study_guide_id UUID
)
RETURNS UUID
LANGUAGE plpgsql
AS $$
DECLARE
    new_set_id UUID;
    fc JSONB;
    curr_user_id UUID;
    s_type set_type := 'flashcards';
BEGIN
    curr_user_id := fetch_current_user_id();

    IF curr_user_id IS NULL THEN
        RAISE EXCEPTION 'Unauthorized: user must be authenticated';
    END IF;

    IF p_folder_id IS NULL THEN 
        p_folder_id := get_folder_id_under_root('Flashcards');
    END IF;

    INSERT INTO "set" (title, user_id, folder_id, study_guide_id, type) 
    VALUES (set_title, curr_user_id, p_folder_id, p_study_guide_id, s_type)
    RETURNING id INTO new_set_id;

    FOREACH fc IN ARRAY flashcards
    LOOP
        INSERT INTO flashcard (set_id, question, answer)
        VALUES (
            new_set_id,
            fc->>'question',
            fc->>'answer'
        );
    END LOOP;

    RETURN new_set_id;
END;
$$;
```
I also realized that we cannot do joins to storage and public  schema, because of that we need to have rpc in order to obtain information about the stored files. Here's the function
 ```sql
CREATE OR REPLACE FUNCTION get_orig_file(
    p_study_guide_id UUID
)
RETURNS TABLE (
    name TEXT,
    bucket TEXT
)
AS $$
BEGIN
    RETURN QUERY
    SELECT
        so1.name AS name,
        so1.bucket_id AS bucket
    FROM
        study_guide sg
    LEFT JOIN
        file f1 ON sg.orig_file_id = f1.id
    LEFT JOIN
        storage.objects so1 ON f1.file_id = so1.id
    WHERE
        sg.id = p_study_guide_id;
END;
$$ LANGUAGE plpgsql SECURITY DEFINER;
```